### PR TITLE
Fix alt text interpolation

### DIFF
--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -11,7 +11,7 @@ const Card = props => {
           <img
             className={styles.logoImage}
             src={withPrefix(`/${props.logo}`)}
-            alt={`Logo for {props.title}`}
+            alt={`Logo for ${props.title}`}
           />
         </a>
       )}


### PR DESCRIPTION
Adds a dropped `$` to card logo alt text so that it interpolates.

Partially addresses #14.