### PR TITLE
typo, fix quotes around link

### DIFF
--- a/src/content/auth/netlify.md
+++ b/src/content/auth/netlify.md
@@ -1,7 +1,7 @@
 ---
 path: "services/auth/netlify"
 title: "Netlify Identity"
-url: https://www.netlify.com/docs/identity/'
+url: "https://www.netlify.com/docs/identity/"
 logo: "/images/netlify.png"
 ---
 


### PR DESCRIPTION
Another very simple typo fix. This time on the URL for Netlify Identify which was missing a `"`. Fixes issue #18 