### PR TITLE
Update Cloudflare Workers URL

### DIFF
--- a/src/content/functions/cloudflare-workers.md
+++ b/src/content/functions/cloudflare-workers.md
@@ -1,7 +1,7 @@
 ---
 path: "services/functions/cloudflare-workers"
 title: "Cloudflare Workers"
-url: "https://www.cloudflare.com/products/cloudflare-workers/"
+url: "https://workers.cloudflare.com/"
 logo: "/images/cloudflare.svg"
 ---
 


### PR DESCRIPTION
New one is the actual product frontpage, the old one was just sales foo.