### PR TITLE
Delete apex because it is still dead

### DIFF
--- a/src/content/functions/apex.md
+++ b/src/content/functions/apex.md
@@ -1,8 +1,0 @@
----
-path: "services/functions/apex"
-title: "Apex"
-url: "http://apex.run/"
-logo: "/images/apex.png"
----
-
-Apex lets you build, deploy, and manage AWS Lambda functions with ease. With Apex you can use languages that are not natively supported by AWS Lambda, such as Golang, through the use of a Node.js shim injected into the build. A variety of workflow related tooling is provided for testing functions, rolling back deploys, viewing metrics, tailing logs, hooking into the build system and more.


### PR DESCRIPTION
Apex is still dead (as it mentioned in issue #118 ) and the repo is archived so it should be removed