### PR TITLE
Re-add Nift

### DIFF
--- a/src/content/ssgs/nift.md
+++ b/src/content/ssgs/nift.md
@@ -1,0 +1,10 @@
+---
+path: "services/ssgs/nift"
+title: "Nift"
+url: "https://nift.dev/"
+logo: "/images/nift-bunny.svg"
+---
+
+Nift is a cross-platform open source framework for managing and generating websites.
+
+It's lightning fast, developed from the ground up in C++, and released for free under the MIT license, use it for any of your personal or commercial projects!


### PR DESCRIPTION
As mentionned in #163, Nift actually still exists, as [nift.dev](https://nift.dev). Though weirdly the redirect from nift.cc to nift.dev (their new URL) doesn’t seem to work in particular situations?